### PR TITLE
Add status 422 to the accepted statuses into succeeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ Instead of returning the default fetch response which contains only status and h
 
 | Methods         | Description                                                                                  | Returns           |
 | --------------- | -------------------------------------------------------------------------------------------- | ----------------- |
-| succeeded       | Check if status is between `200` and `300` and if there is no error.                         | `boolean`         |
-| bodyIfSucceeded | Return the body of the request if the status is between `200` and `300` else return `false`. | `body` or `false` |
-| bodyOrThrow     | Return the body of the request if the status is between `200` and `300` else throw a error.  | `body` or throw   |
+| succeeded       | Check if status is between `200` and `300` or `422` and if there is no error.                         | `boolean`         |
+| bodyIfSucceeded | Return the body of the request if the status is between `200` and `300` or `422` else return `false`. | `body` or `false` |
+| bodyOrThrow     | Return the body of the request if the status is between `200` and `300` or `422` else throw a error.  | `body` or throw   |
 | didNetworkFail  | If the network request failed, return `true` or `false`                                      | `boolean`         |
 | didServerFail   | Tell you if you get error from the server.                                                   | `boolean`         |
 

--- a/__tests__/response.test.js
+++ b/__tests__/response.test.js
@@ -35,9 +35,10 @@ describe('Response', () => {
   });
 
   describe('succeeded', () => {
-    it('returns true if request status is among 200-300', () => {
+    it('returns true if request status is among 200-300 or 422', () => {
       expect(new Response({ status: 200 }).succeeded).toBeTruthy();
       expect(new Response({ status: 299 }).succeeded).toBeTruthy();
+      expect(new Response({ status: 422 }).succeeded).toBeTruthy();
       expect(new Response({ status: 250 }).succeeded).toBeTruthy();
       expect(new Response({ status: 300 }).succeeded).toBeFalsy();
     });

--- a/src/response.js
+++ b/src/response.js
@@ -34,8 +34,9 @@ export default class Response {
   }
 
   get succeeded() {
-    return !this.error
+    return (!this.error
         && this.status >= 200
-        && this.status < 300;
+        && this.status < 300)
+        || this.status === 422;
   }
 }


### PR DESCRIPTION
We needed status 422 to not through an error on the client because it does not mean that the request failed but means that the server returned us an error.